### PR TITLE
fix: accidental extra kromer for players who have already recieved their wallet

### DIFF
--- a/src/main/java/cc/reconnected/kromer/Kromer.java
+++ b/src/main/java/cc/reconnected/kromer/Kromer.java
@@ -349,15 +349,21 @@ public class Kromer implements DedicatedServerModInitializer {
         UUID uuid,
         ServerPlayer player
     ) {
+        AfkPlayerData solsticeData = Solstice.modules
+                .getModule(AfkModule.class)
+                .get()
+                .getPlayerData(uuid);
+        WelfareData welfareData = Solstice.playerData
+                .get(player.getUUID())
+                .getData(WelfareData.class);
+        if (welfareData.oldActiveTime == 0) {
+            welfareData.oldActiveTime = solsticeData.activeTime; // Prevent double retroactive kromer.
+        }
         if (database.getWallet(uuid) != null) {
             return;
         }
 
         // Retroactive KRO giving
-        AfkPlayerData solsticeData = Solstice.modules
-            .getModule(AfkModule.class)
-                .get()
-            .getPlayerData(uuid);
         float kroAmountRaw = (float) (((double) solsticeData.activeTime /
                 3600) *
                 config.HourlyWelfare());
@@ -395,10 +401,7 @@ public class Kromer implements DedicatedServerModInitializer {
                                         if (ex2 != null) {
                                             LOGGER.error("Failed to give retroactive kro to " + name, ex2);
                                         }
-                                        WelfareData welfareData = Solstice.playerData
-                                                .get(player.getUUID())
-                                                .getData(WelfareData.class);
-                                        welfareData.oldActiveTime = solsticeData.activeTime; // Prevent double retroactive kromer.
+
                                     });
                         }
                     } else if (createWalletResult instanceof Result.Err<CreateWallet.CreateWalletResponse> err) {


### PR DESCRIPTION
apparently that's too long for a git commit name, but whatever. emergency commit to fix this
<img width="625" height="80" alt="image" src="https://github.com/user-attachments/assets/503611c1-9efe-49b4-a841-7cd6067d3193" />
(its exaggerated, but it would effectively apply a retroactive kromer bonus to those who have already recieved their wallet, as this case was not tested